### PR TITLE
Add dockerfile and basic instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+RUN apt update
+RUN apt install -y software-properties-common python3 python3-pip npm
+RUN apt install -y libgtk2.0-dev openctm-tools
+RUN add-apt-repository --yes ppa:kicad/kicad-6.0-releases
+RUN apt update
+RUN apt install -y --install-recommends kicad
+RUN npm install -g easyeda2kicad
+RUN git clone https://github.com/yaqwsx/EasyEDAFootprintScraper.git
+RUN pip3 install requests click
+
+WORKDIR EasyEDAFootprintScraper
+ENTRYPOINT ["/usr/bin/python3", "fetchComponent.py"]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,18 @@ Just run:
 ```
 
 It will create a KiCAD library `test.pretty` and `test.3dshapes` in the working
-directory. There will be a footprint for component C558438and a corresponding 3D
+directory. There will be a footprint for component C558438 and a corresponding 3D
 model. To actually view the 3D models in KiCAD, you have to configure a KiCAD
 variable `EASY_EDA_3D` pointing to a directory with `test.3dshapes`.
+
+### Docker
+On macOS and Windows, it's a pain to expose the Kicad Python interface and install ctmconv. Instead, running inside Docker works perfectly to grab footprints and 3D models - no dependencies needed on the host system.
+
+1. Build the docker container (run from the root of this repository).
+  `docker build . --tag=fetchcomponent`
+2. Run the container.
+  `docker run --rm -v $(pwd):/output fetchcomponent fetchlcsc --kicadLib /output/test.pretty --force C558438`
+
 
 ## Known issues
 


### PR DESCRIPTION
First, thank you for this wonderful tool! Getting canonical footprints direct from LCSC streamlines my workflow and honestly sparks joy - I focus on design rather than mechanically recreating footprints and models.

I found it a bit difficult to get fetchComponent working on macOS. There are two main challenges:
1. making the Kicad-specific python packages (pcbnew) accessible to python. The best way I found was to use the python install embedded with in the Kicad app package (`/Applications/Kicad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3`). This works, but is unwieldy.
2. Installing ctmconv. I can't find prebuilt binaries on the usual macOS package managers, so I'd have to install from source.

Instead of fighting through brittle install steps on macOS, I've packed up the fetchComponent tool into a Ubuntu-based docker container. This should run with no further dependencies (beyond Docker) on pretty much any platform, and seems to maintain full functionality.

Again, thanks @yaqwsx for the original code, and I hope this Docker-based option helps someone else!